### PR TITLE
Prefix by branch

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -14,7 +14,7 @@ buildscript {
     }
 }
 
-version = "1.0.8-ALPHA"
+version = "1.0.9-ALPHA"
 
 apply plugin: "com.dipien.android.semantic-version"
 

--- a/jenkins/create-release.sh
+++ b/jenkins/create-release.sh
@@ -1,6 +1,10 @@
 #!/bin/bash -x
 
 versionName=$(./gradlew printVersion -Palpha=true -Pbeta=true | grep "Version name:" | cut -d ' ' -f 3 | sed -e 's/^[[:space:]]*//')
+if [[ "$GIT_BRANCH" != "main" && "$GIT_BRANCH" != "master" ]]; then {
+    # We're in a feature branch or whatever, so we'll use the branch name as a prefix
+    versionName="$GIT_BRANCH-$versionName"
+} fi
 echo "Release version: ${versionName}"
 # -d Save the release as a draft instead of publishing it...
 # -p Mark the release as a prerelease

--- a/jenkins/release-already-exists.sh
+++ b/jenkins/release-already-exists.sh
@@ -1,6 +1,10 @@
-#!/bin/sh
+#!/bin/bash -x
 
 versionName=$(./gradlew printVersion -Palpha=true -Pbeta=true | grep "Version name:" | cut -d ' ' -f 3 | sed -e 's/^[[:space:]]*//')
+if [[ "$GIT_BRANCH" != "main" && "$GIT_BRANCH" != "master" ]]; then {
+    # We're in a feature branch or whatever, so we'll use the branch name as a prefix
+    versionName="$GIT_BRANCH-$versionName"
+} fi
 # echo "Release version: ${versionName}"
 
 versionCode=$(./gradlew printVersion -Palpha=true -Pbeta=true | grep "Version code:" | grep -o '[^ ]*$' | sed -e 's/^[[:space:]]*//')


### PR DESCRIPTION
Now creates releases with the name of the branch as a prefix (except for `main` or `master`).

Closes  #13 .