### PR TITLE
No more dond

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -73,5 +73,5 @@ RUN chown -R jenkins:jenkins "${JENKINS_AGENT_HOME}" && chmod +x "${JENKINS_AGEN
 #COPY . .
 #COPY gradlew ${JENKINS_AGENT_HOME}
 
-#COPY entrypoint.sh /entrypoint.sh
-ENTRYPOINT [ "bash", "-c"]
+# COPY entrypoint.sh /entrypoint.sh
+# ENTRYPOINT [ "bash", "-c"]

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -57,11 +57,7 @@ pipeline {
                 ANDROID_PUBLISHER_CREDENTIALS = credentials('android-publisher-credentials')
             }
             agent {
-                docker {
-                    alwaysPull true
-                    image "gounthar/jenkinsci-docker-android-base:${BRANCH_NAME}"
-                    label 'ubuntu'
-                }
+                label 'android'
             }
             steps {
                 script {

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -84,7 +84,7 @@ pipeline {
             }
             steps {
                 echo 'Run unit tests from the source code'
-                sh './gradlew test'
+                sh 'chmod +x gradlew && ./gradlew test'
             }
         }
         stage('Run Instrumented Tests') {

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -80,11 +80,7 @@ pipeline {
         }
         stage('Run Unit Tests') {
             agent {
-                docker {
-                    alwaysPull true
-                    image "gounthar/jenkinsci-docker-android-base:${BRANCH_NAME}"
-                    label 'ubuntu'
-                }
+                label 'android'
             }
             steps {
                 echo 'Run unit tests from the source code'
@@ -93,11 +89,7 @@ pipeline {
         }
         stage('Run Instrumented Tests') {
             agent {
-                docker {
-                    alwaysPull true
-                    image "gounthar/jenkinsci-docker-android-base:${BRANCH_NAME}"
-                    label 'ubuntu'
-                }
+                label 'android'
             }
             steps {
                 echo 'Run only instrumented tests from the source code'
@@ -118,11 +110,7 @@ pipeline {
                 ANDROID_PUBLISHER_CREDENTIALS = credentials('android-publisher-credentials')
             }
             agent {
-                docker {
-                    alwaysPull true
-                    image "gounthar/jenkinsci-docker-android-base:${BRANCH_NAME}"
-                    label 'ubuntu'
-                }
+                label 'android'
             }
             steps {
                 script {
@@ -147,11 +135,7 @@ pipeline {
                 ANDROID_PUBLISHER_CREDENTIALS = credentials('android-publisher-credentials')
             }
             agent {
-                docker {
-                    alwaysPull true
-                    image "gounthar/jenkinsci-docker-android-base:${BRANCH_NAME}"
-                    label 'ubuntu'
-                }
+                label 'android'
             }
             steps {
                 echo 'Publishes the bundle on the Google Play Store'

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -26,11 +26,7 @@ pipeline {
             parallel {
                 stage('Static Analysis with gradlew check') {
                     agent {
-                        docker {
-                            alwaysPull true
-                            image "gounthar/jenkinsci-docker-android-base:${BRANCH_NAME}"
-                            label 'ubuntu'
-                        }
+                        label 'android'
                     }
                     steps {
                         echo 'Run the static analysis to the code'

--- a/jenkins/agent/entrypoint.sh
+++ b/jenkins/agent/entrypoint.sh
@@ -4,9 +4,15 @@ set -eux -o pipefail
 
 # Pre Hooks
 # Prepare Permissions by adding jenkins to the group owner of /var/run/docker.sock (this GID changes on different hosts/docker engines)
-#dockersock_growner_id="$(stat -c "%g" /var/run/docker.sock)"
-delgroup docker || true
-addgroup docker --gid "${dockersock_growner_id}" || true
+dockersock_growner_id="$(stat -c "%g" /var/run/docker.sock)"
+if [[ "$dockersock_growner_id" == "0" ]]; then
+  chown root:docker /var/run/docker.sock
+  chmod 660 /var/run/docker.sock
+else
+  delgroup docker || true
+  addgroup docker --gid "${dockersock_growner_id}"
+fi
 adduser jenkins docker
+
 # Run default entrypoint
 exec /usr/local/bin/setup-sshd "$@"

--- a/jenkins/casc.d/agents.yaml
+++ b/jenkins/casc.d/agents.yaml
@@ -10,7 +10,20 @@ jenkins:
             sshHostKeyVerificationStrategy: "nonVerifyingKeyVerificationStrategy"
         name: "jenkins-agent"
         nodeDescription: "SSH agent used to execute builds"
-        numExecutors: 2
+        numExecutors: 4
+        remoteFS: "/home/jenkins"
+        retentionStrategy: "always"
+    - permanent:
+        labelString: "android"
+        launcher:
+          ssh:
+            credentialsId: "jenkins-agent-ssh-key"
+            host: "android-agent"
+            port: 22
+            sshHostKeyVerificationStrategy: "nonVerifyingKeyVerificationStrategy"
+        name: "android-agent"
+        nodeDescription: "SSH agent used to execute Android builds"
+        numExecutors: 4
         remoteFS: "/home/jenkins"
         retentionStrategy: "always"
     - permanent:

--- a/jenkins/docker-compose.yml
+++ b/jenkins/docker-compose.yml
@@ -26,6 +26,14 @@ services:
             - /var/run/docker.sock:/var/run/docker.sock:rw
         environment:
             - JENKINS_AGENT_SSH_PUBKEY=ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIBpNqXQ4x7fPPUBbYPxKF77Zqq6d35iPCD2chg644OUD noone@localhost.local
+    android-agent:
+        build: ../
+        restart: unless-stopped
+        volumes:
+            - android-agent-data:/home/jenkins:rw
+        environment:
+            - JENKINS_AGENT_SSH_PUBKEY=ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIBpNqXQ4x7fPPUBbYPxKF77Zqq6d35iPCD2chg644OUD
 volumes:
     jenkins-data:
     jenkins-agent-data:
+    android-agent-data:


### PR DESCRIPTION
* fix(docker) Adding an `android` agent to avoid DonD.

* fix(docker) Adding an `android` agent to avoid DonD.

* fix(docker) Now using the `ssh-agent` base entrypoint

* fix(docker) `chown` and `chmod` whenever the `docker.sock` belongs to root.

* feat(jenkins) now uses a dedicated `android` agent

Instead of a `DonD` generic one.

* fix(jenkins) Let's use directly the agent with the right docker image

instead of using it through a docker image.

* fix(jenkins) Let's use directly the agent with the right docker image

instead of using it through a docker image.

* fix(jenkins) `gradlew: permission denied