### PR TITLE
Gradlew permissions

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -8,6 +8,7 @@ plugins {
     id("com.gradleup.static-analysis") version "1.4"
     id("com.github.spotbugs") version "5.0.9"
     id("io.gitlab.arturbosch.detekt")
+    id 'jacoco'
 }
 
 android {
@@ -81,7 +82,7 @@ android {
 dependencies {
 
     implementation 'androidx.core:core-ktx:1.8.0'
-    implementation 'androidx.appcompat:appcompat:1.4.2'
+    implementation 'androidx.appcompat:appcompat:1.5.0'
     implementation 'com.google.android.material:material:1.6.1'
     implementation 'androidx.constraintlayout:constraintlayout:2.1.4'
     implementation 'androidx.lifecycle:lifecycle-livedata-ktx:2.5.1'

--- a/jenkins/create-gps-release.sh
+++ b/jenkins/create-gps-release.sh
@@ -57,7 +57,7 @@ publishOnPlayStore(){
     # https://github.com/Triple-T/gradle-play-publisher#uploading-developer-facing-release-names
     # Note: the Play Store limits your release names to a maximum of 50 characters.
     printf %s "${versionName:0:500}" > $releaseNamesDir/internal.txt
-    chmod +x ./gradlew && /gradlew publishBundle
+    chmod +x ./gradlew && ./gradlew publishBundle
 }
 
 suffix=$(echo $versionName | sed 's/.*-//')


### PR DESCRIPTION
* feat(android) Add jacoco plugin

Getting Started
https://docs.gradle.org/current/userguide/jacoco_plugin.html#sec:jacoco_getting_started

* fix(android) 15 warnings is acceptable

* Update the Jacoco branch with latest commits from main. (#72)

* Damien cleanup to main (#66)

* feat(ci/cd): Now builds with the static docker agent

Hopefully... Trying to get a docker agent to take the dockerfile, build a docker image, and use it to build the app

BREAKING CHANGE: Have to have a static docker agent able to take the build

* feat(docker): Install docker in the image

Will that be enough to get DinD?

* feat(docker): Start from Debian instead of ssh-agent

Will that be enough to get DinD?

* fix(docker): chown: invalid user: 'jenkins:jenkins'

* fix(docker): developer and not developers

* feat(docker): Install docker for non root user

To run Docker as a non-privileged user, consider setting up the Docker daemon in rootless mode for your user.
Visit https://docs.docker.com/go/rootless/ to learn about rootless mode.

* feat(docker): Do not install docker for non root user

Refusing to install rootless Docker as the root user

* chore(docker): Now using Android SDK Build-Tools 30.0.3

* chore(docker): No need to know the docker version

* chore(docker): No need to install the recommended software

* chore(android): Updated a few dependencies. New patch version.

- androidx.lifecycle:lifecycle-livedata-ktx:2.5.1
- androidx.lifecycle:lifecycle-viewmodel-ktx:2.5.1
- androidx.navigation:navigation-fragment-ktx:2.5.1
- androidx.navigation:navigation-ui-ktx:2.5.1

* fix(jenkins): gradle may need a signin profile even for compiling.

* fix(android): Trying to fix debug.keystore.lock does not exist

Parent directory of /home/jenkins/workspace/Pipeline stored on GitHub repo/?/.gradle/daemon/7.3.3/?/.android/debug.keystore.lock does not exist

* fix(jenkins): is the checkout really necessary?

* fix(jenkins): Expected one of "steps", "stages", or "parallel" for stage "Checkout"

* fix(gradle) android should work now

* fix(docker): No more dockerfile: true because of bugs

* fix(docker): Missing required section "agent" @ line 1, column 1.

* fix(docker): Missing required section "agent" @ line 1, column 1.

* chore(docker) add image to build

* feat(docker): Trying to get the branch name as the docker image tag.

* fix(docker): Trying to use a variable for the docker image name as...

Tag must follow the pattern &#039;^:[a-zA-Z0-9_]([a-zA-Z0-9_.-]){0,127}&#039;

* fix(docker): No such property: $DOCKER_IMAGE_NAME for class: groovy.lang.Binding

* fix(docker): No such property: $env for class: groovy.lang.Binding

https://stackoverflow.com/a/59877617/2938320

* fix(docker): ERROR: Bad imageName format: null

* fix(docker): expecting '}', found '' @ line 109, column 1.

* fix(docker): ${env.DOCKER_IMAGE_NAME} cannot be used as a value directly.

Did you mean "${env.DOCKER_IMAGE_NAME}"? (add quotes)

* fix(docker): Unable to contact docker apparently

Remote call on JNLP4-connect connection from 172.18.0.1/172.18.0.1:60178 failed

* fix(docker): There are no nodes with the label ‘linux ubuntu docker

* fix(docker) use a function to get the branch name

* fix(docker) get the right branch name

Is is possible to get the branch name in the on/push/branches?

* fix(docker): $HOME not defined is maybe the root cause of all my problems.

* fix(docker): it looks like the last image is not always pulled

* fix(jenkins): is $HOME finally set?

* fix(jenkins): $HOME is, what else could be the `?` ?

* fix(docker): another try at getting the Jenkins user right.

* chore(android): Updated a few dependencies and removed jcenter.

* fix(docker): another try at getting the Jenkins user right.

* Conditional docker building (#40)

* feat(github): Should only build the docker image if Dockerfile got changed.

* feat(github): Should only build the docker image if Dockerfile got changed.

* feat(github): Should only build the docker image if Dockerfile got changed.

* feat(github): Should only build the docker image if Dockerfile got changed.

* feat(github): Should only build the docker image if Dockerfile got changed.

* feat(android): Added the first static analytics tools

* feat(android): Added the first static analytics tools

* fix(android): Removed temporarily the detekt tool.

Problems to set it up.

* fix(android): detekt wants the `.kt` files to end up with a newline.

* fix(android): detekt wants the `.kt` files to end up with a newline.

* feat(android) Add a qodana docker stage

* fix(docker) Now builds the docker image for the qodana branch

* feat(action) Try to guess if the image already exists

* Get latest commits merged into qodana branch (#61)

* Create codacy.yml

* Bump gradle from 7.2.1 to 7.2.2 (#36)

Bumps gradle from 7.2.1 to 7.2.2.

---
updated-dependencies:
- dependency-name: com.android.tools.build:gradle
  dependency-type: direct:production
  update-type: version-update:semver-patch
...

Signed-off-by: dependabot[bot] <support@github.com>

Co-authored-by: dependabot[bot] <49699333+dependabot[bot]@users.noreply.github.com>

* Release drafter (#37)

* Syntax is now correct.

* Added the configuration file.

* Only works on the `main` branch.

* chore(android): Upgrade semantic version plugin to 1.2.0

* Closes #34 (#38)

* Syntax is now correct.

* Added the configuration file.

* Only works on the `main` branch.

* chore(android): Upgrade semantic version plugin to 1.2.0

* feat(github): Supposed to resolve #34

* chore(android): Upgrade version to 1.0.17

* Dynamic docker (#50)

* feat(ci/cd): Now builds with the static docker agent

Hopefully... Trying to get a docker agent to take the dockerfile, build a docker image, and use it to build the app

BREAKING CHANGE: Have to have a static docker agent able to take the build

* feat(docker): Install docker in the image

Will that be enough to get DinD?

* feat(docker): Start from Debian instead of ssh-agent

Will that be enough to get DinD?

* fix(docker): chown: invalid user: 'jenkins:jenkins'

* fix(docker): developer and not developers

* feat(docker): Install docker for non root user

To run Docker as a non-privileged user, consider setting up the Docker daemon in rootless mode for your user.
Visit https://docs.docker.com/go/rootless/ to learn about rootless mode.

* feat(docker): Do not install docker for non root user

Refusing to install rootless Docker as the root user

* chore(docker): Now using Android SDK Build-Tools 30.0.3

* chore(docker): No need to know the docker version

* chore(docker): No need to install the recommended software

* chore(android): Updated a few dependencies. New patch version.

- androidx.lifecycle:lifecycle-livedata-ktx:2.5.1
- androidx.lifecycle:lifecycle-viewmodel-ktx:2.5.1
- androidx.navigation:navigation-fragment-ktx:2.5.1
- androidx.navigation:navigation-ui-ktx:2.5.1

* fix(jenkins): gradle may need a signin profile even for compiling.

* fix(android): Trying to fix debug.keystore.lock does not exist

Parent directory of /home/jenkins/workspace/Pipeline stored on GitHub repo/?/.gradle/daemon/7.3.3/?/.android/debug.keystore.lock does not exist

* fix(jenkins): is the checkout really necessary?

* fix(jenkins): Expected one of "steps", "stages", or "parallel" for stage "Checkout"

* fix(gradle) android should work now

* fix(docker): No more dockerfile: true because of bugs

* fix(docker): Missing required section "agent" @ line 1, column 1.

* fix(docker): Missing required section "agent" @ line 1, column 1.

* chore(docker) add image to build

* feat(docker): Trying to get the branch name as the docker image tag.

* fix(docker): Trying to use a variable for the docker image name as...

Tag must follow the pattern &#039;^:[a-zA-Z0-9_]([a-zA-Z0-9_.-]){0,127}&#039;

* fix(docker): No such property: $DOCKER_IMAGE_NAME for class: groovy.lang.Binding

* fix(docker): No such property: $env for class: groovy.lang.Binding

https://stackoverflow.com/a/59877617/2938320

* fix(docker): ERROR: Bad imageName format: null

* fix(docker): expecting '}', found '' @ line 109, column 1.

* fix(docker): ${env.DOCKER_IMAGE_NAME} cannot be used as a value directly.

Did you mean "${env.DOCKER_IMAGE_NAME}"? (add quotes)

* fix(docker): Unable to contact docker apparently

Remote call on JNLP4-connect connection from 172.18.0.1/172.18.0.1:60178 failed

* fix(docker): There are no nodes with the label ‘linux ubuntu docker

* fix(docker) use a function to get the branch name

* fix(docker) get the right branch name

Is is possible to get the branch name in the on/push/branches?

* fix(docker): $HOME not defined is maybe the root cause of all my problems.

* fix(docker): it looks like the last image is not always pulled

* fix(jenkins): is $HOME finally set?

* fix(jenkins): $HOME is, what else could be the `?` ?

* fix(docker): another try at getting the Jenkins user right.

* chore(android): Updated a few dependencies and removed jcenter.

* fix(docker): another try at getting the Jenkins user right.

* Conditional docker building (#40)

* feat(github): Should only build the docker image if Dockerfile got changed.

* feat(github): Should only build the docker image if Dockerfile got changed.

* feat(github): Should only build the docker image if Dockerfile got changed.

* feat(github): Should only build the docker image if Dockerfile got changed.

* feat(github): Should only build the docker image if Dockerfile got changed.

* feat(android): Added the first static analytics tools

* feat(android): Added the first static analytics tools

* fix(android): Removed temporarily the detekt tool.

Problems to set it up.

* fix(android): detekt wants the `.kt` files to end up with a newline.

* fix(android): detekt wants the `.kt` files to end up with a newline.

* fix(android): detekt generated its own config file.

* chore(android): New patch version

This way, we should see if the application goes up to the Play Store.

* fix(docker) The build has to happen in the main branch.

* Bump com.github.spotbugs from 4.7.1 to 5.0.9 (#54)

Bumps com.github.spotbugs from 4.7.1 to 5.0.9.

---
updated-dependencies:
- dependency-name: com.github.spotbugs
  dependency-type: direct:production
  update-type: version-update:semver-major
...

Signed-off-by: dependabot[bot] <support@github.com>

Signed-off-by: dependabot[bot] <support@github.com>
Co-authored-by: dependabot[bot] <49699333+dependabot[bot]@users.noreply.github.com>

* Add gradle wrapper binary (#57)

* chore(docker): Allow docker to copy everything but...

* feat(docker): Docker should now download the correct version of gradle

* chore(docker): GitHub action has to use the add-gradle-wrapper-binary to build

* fix(jenkins): where does gradlew store the gradle jar?

* fix(jenkins): is there anything in the wrapper dir?

* fix(jenkins): is there anything in the wrapper dir?

* fix(jenkins): nothing in target dir :'(

Would there be anything after the first gradle command in the container using our image?

* fix(jenkins): nothing in target dir :'(

Would there be anything after the first gradle command in the container using our image?

* fix(jenkins): unexpected char: '\' @ line 24, column 67.

* fix(docker): Trying to find the gradle jar

* fix(docker): Trying to find the gradle jar

* fix(docker): Trying to find the gradle jar

* fix(docker): Trying to find the gradle jar

* fix(docker): Trying to find the gradle jar

* fix(docker): Trying to find the gradle jar

* feat(jenkins) Can detekt autocorrect?

* feat(android) First level of tests

* feat(github) Docker image building should now react on...

`.dockerignore` and `gradle/wrapper/gradle-wrapper.properties`.

* fix(github) misprint

The workflow is not valid. .github/workflows/docker-image.yml (Line: 33, Col: 13): Unexpected symbol: 'v'. Located at position 86 within expression: steps.filter.outputs.docker == 'true' || steps.filter.outputs.docker-ignore == 'true'v || steps.filter.outputs.grqdle-zrqpper == 'true'

* chore(docker) Move to JDK17

* feat(android) Added the buildToolsVersion to be used later on to configure the Docker image.

* fix(github) "Dockerfile" as an answer does not seem to work.

Let's try with `true`

* fix(github) The test was not well written

* fix(github) The test was not well written

* fix(github) The workflow is not valid.

.github/workflows/docker-image.yml (Line: 37, Col: 9): Unrecognized named-value: 'paths-filter'. Located at position 1 within expression: paths-filter.changes.outputs.docker == 'true' || paths-filter.changes.outputs.docker-ignore == 'true' || paths-filter.changes.outputs.gradle-wrapper == 'true'

* fix(github) You have an error in your yaml syntax on line 8

`*` is not a valid branch name. `'*'` is.

* fix(github) Changes output set to ["docker","docker-ignore"]

Let's compare with an empty array?

* fix(github) Unexpected symbol: '['. Ugly hack

https://github.com/orgs/community/discussions/27125#discussioncomment-3254717

* fix(github) Too few parameters supplied: '('.

https://github.com/orgs/community/discussions/27125#discussioncomment-3254717

* fix(github) Too few parameters supplied: '('.

https://github.com/orgs/community/discussions/27125#discussioncomment-3254717

* fix(github) Unexpected symbol: '‘'.

https://github.com/orgs/community/discussions/27125#discussioncomment-3254717

* fix(github) Still false...

* feat(docker) Let's see if the gradle dist zip file is there

* feat(docker) Let's see if the gradle dist zip file is there

* feat(docker) Let's see if the gradle dist zip file is there

* feat(docker) Let's see if the gradle dist zip file is there

* feat(docker) Let's see if the gradle dist zip file is there

* fix(jenkins) We don't have any device connected yet

* fix(jenkins) We don't have any device connected yet, do we?

* feat(docker) adb binary is needed to connect

* Docker image tag name (#59)

* fix(docker) invalid tag "***/***:refs/pull/57/merge": invalid reference format

* fix(jenkins) if we change the nomenclature for the dockerfile tag in the GH workflow...

We also have to change it within Jenkins.

Signed-off-by: dependabot[bot] <support@github.com>
Co-authored-by: dependabot[bot] <49699333+dependabot[bot]@users.noreply.github.com>

* fix(jenkins) No need to do static analysis to test qodana

* fix(jenkins) No need to do static analysis to test qodana

* feat(jenkins) one agent per stage now, as we will have to use different images.

* fix(jenkins) No such property: GIT_BRANCH for class: groovy.lang.Binding

* fix(jenkins) pull access denied for jetbrains/qodana-android, repository does not exist

* feat(android) Added qodana configuration file

* fix(android) Violations limit exceeded by 0 errors, 12 warnings.

Let's push to 15.

* fix(jenkins) No need to checkout, right?

* fix(jenkins) No need to checkout, right?

* fix(jenkins) No need to checkout, right?

* fix(jenkins) Avoid the Jenkins agent running in Docker on top of Windows

* feat(docker) Help from Damien to get DinD running in my agents.

* feat(docker) Add a checksum for the maven binary

* feat(docker) Android SDK is back.

* feat(jenkins) Have a distinct name for each stage

* feat(jenkins) First try at Jcasc.

* feat(jenkins) Gitpodization

* fix(docker) Warning: Failed to find package 'ndk;21.4.7075529'

* chore(git) no secrets, sorry.

* fix(jcasc) Agents should have the `docker` and `ubuntu` labels.

* feat(docker) Adding a named data volume and a few ENV variables for secrets.

* feat(docker) Poor man's Jcasc.

Adding First Job as a job that will appear in any new controller instance when using this Dockerfile.

* feat(jcasc) First try at getting the GitHub app credentials.

* feat(jcasc) First try at getting a First Job as part of the initial installation

Signed-off-by: dependabot[bot] <support@github.com>
Co-authored-by: dependabot[bot] <49699333+dependabot[bot]@users.noreply.github.com>

* fix(docker) The port 50k could not be seen.

* fix(docker) New simplified Dockerfile for the agent, and a q&d fix for ssh

* Damien cleanup (#67)

* feat(ci/cd): Now builds with the static docker agent

Hopefully... Trying to get a docker agent to take the dockerfile, build a docker image, and use it to build the app

BREAKING CHANGE: Have to have a static docker agent able to take the build

* feat(docker): Install docker in the image

Will that be enough to get DinD?

* feat(docker): Start from Debian instead of ssh-agent

Will that be enough to get DinD?

* fix(docker): chown: invalid user: 'jenkins:jenkins'

* fix(docker): developer and not developers

* feat(docker): Install docker for non root user

To run Docker as a non-privileged user, consider setting up the Docker daemon in rootless mode for your user.
Visit https://docs.docker.com/go/rootless/ to learn about rootless mode.

* feat(docker): Do not install docker for non root user

Refusing to install rootless Docker as the root user

* chore(docker): Now using Android SDK Build-Tools 30.0.3

* chore(docker): No need to know the docker version

* chore(docker): No need to install the recommended software

* chore(android): Updated a few dependencies. New patch version.

- androidx.lifecycle:lifecycle-livedata-ktx:2.5.1
- androidx.lifecycle:lifecycle-viewmodel-ktx:2.5.1
- androidx.navigation:navigation-fragment-ktx:2.5.1
- androidx.navigation:navigation-ui-ktx:2.5.1

* fix(jenkins): gradle may need a signin profile even for compiling.

* fix(android): Trying to fix debug.keystore.lock does not exist

Parent directory of /home/jenkins/workspace/Pipeline stored on GitHub repo/?/.gradle/daemon/7.3.3/?/.android/debug.keystore.lock does not exist

* fix(jenkins): is the checkout really necessary?

* fix(jenkins): Expected one of "steps", "stages", or "parallel" for stage "Checkout"

* fix(gradle) android should work now

* fix(docker): No more dockerfile: true because of bugs

* fix(docker): Missing required section "agent" @ line 1, column 1.

* fix(docker): Missing required section "agent" @ line 1, column 1.

* chore(docker) add image to build

* feat(docker): Trying to get the branch name as the docker image tag.

* fix(docker): Trying to use a variable for the docker image name as...

Tag must follow the pattern &#039;^:[a-zA-Z0-9_]([a-zA-Z0-9_.-]){0,127}&#039;

* fix(docker): No such property: $DOCKER_IMAGE_NAME for class: groovy.lang.Binding

* fix(docker): No such property: $env for class: groovy.lang.Binding

https://stackoverflow.com/a/59877617/2938320

* fix(docker): ERROR: Bad imageName format: null

* fix(docker): expecting '}', found '' @ line 109, column 1.

* fix(docker): ${env.DOCKER_IMAGE_NAME} cannot be used as a value directly.

Did you mean "${env.DOCKER_IMAGE_NAME}"? (add quotes)

* fix(docker): Unable to contact docker apparently

Remote call on JNLP4-connect connection from 172.18.0.1/172.18.0.1:60178 failed

* fix(docker): There are no nodes with the label ‘linux ubuntu docker

* fix(docker) use a function to get the branch name

* fix(docker) get the right branch name

Is is possible to get the branch name in the on/push/branches?

* fix(docker): $HOME not defined is maybe the root cause of all my problems.

* fix(docker): it looks like the last image is not always pulled

* fix(jenkins): is $HOME finally set?

* fix(jenkins): $HOME is, what else could be the `?` ?

* fix(docker): another try at getting the Jenkins user right.

* chore(android): Updated a few dependencies and removed jcenter.

* fix(docker): another try at getting the Jenkins user right.

* Conditional docker building (#40)

* feat(github): Should only build the docker image if Dockerfile got changed.

* feat(github): Should only build the docker image if Dockerfile got changed.

* feat(github): Should only build the docker image if Dockerfile got changed.

* feat(github): Should only build the docker image if Dockerfile got changed.

* feat(github): Should only build the docker image if Dockerfile got changed.

* feat(android): Added the first static analytics tools

* feat(android): Added the first static analytics tools

* fix(android): Removed temporarily the detekt tool.

Problems to set it up.

* fix(android): detekt wants the `.kt` files to end up with a newline.

* fix(android): detekt wants the `.kt` files to end up with a newline.

* feat(android) Add a qodana docker stage

* fix(docker) Now builds the docker image for the qodana branch

* feat(action) Try to guess if the image already exists

* Get latest commits merged into qodana branch (#61)

* Create codacy.yml

* Bump gradle from 7.2.1 to 7.2.2 (#36)

Bumps gradle from 7.2.1 to 7.2.2.

---
updated-dependencies:
- dependency-name: com.android.tools.build:gradle
  dependency-type: direct:production
  update-type: version-update:semver-patch
...

Signed-off-by: dependabot[bot] <support@github.com>

Co-authored-by: dependabot[bot] <49699333+dependabot[bot]@users.noreply.github.com>

* Release drafter (#37)

* Syntax is now correct.

* Added the configuration file.

* Only works on the `main` branch.

* chore(android): Upgrade semantic version plugin to 1.2.0

* Closes #34 (#38)

* Syntax is now correct.

* Added the configuration file.

* Only works on the `main` branch.

* chore(android): Upgrade semantic version plugin to 1.2.0

* feat(github): Supposed to resolve #34

* chore(android): Upgrade version to 1.0.17

* Dynamic docker (#50)

* feat(ci/cd): Now builds with the static docker agent

Hopefully... Trying to get a docker agent to take the dockerfile, build a docker image, and use it to build the app

BREAKING CHANGE: Have to have a static docker agent able to take the build

* feat(docker): Install docker in the image

Will that be enough to get DinD?

* feat(docker): Start from Debian instead of ssh-agent

Will that be enough to get DinD?

* fix(docker): chown: invalid user: 'jenkins:jenkins'

* fix(docker): developer and not developers

* feat(docker): Install docker for non root user

To run Docker as a non-privileged user, consider setting up the Docker daemon in rootless mode for your user.
Visit https://docs.docker.com/go/rootless/ to learn about rootless mode.

* feat(docker): Do not install docker for non root user

Refusing to install rootless Docker as the root user

* chore(docker): Now using Android SDK Build-Tools 30.0.3

* chore(docker): No need to know the docker version

* chore(docker): No need to install the recommended software

* chore(android): Updated a few dependencies. New patch version.

- androidx.lifecycle:lifecycle-livedata-ktx:2.5.1
- androidx.lifecycle:lifecycle-viewmodel-ktx:2.5.1
- androidx.navigation:navigation-fragment-ktx:2.5.1
- androidx.navigation:navigation-ui-ktx:2.5.1

* fix(jenkins): gradle may need a signin profile even for compiling.

* fix(android): Trying to fix debug.keystore.lock does not exist

Parent directory of /home/jenkins/workspace/Pipeline stored on GitHub repo/?/.gradle/daemon/7.3.3/?/.android/debug.keystore.lock does not exist

* fix(jenkins): is the checkout really necessary?

* fix(jenkins): Expected one of "steps", "stages", or "parallel" for stage "Checkout"

* fix(gradle) android should work now

* fix(docker): No more dockerfile: true because of bugs

* fix(docker): Missing required section "agent" @ line 1, column 1.

* fix(docker): Missing required section "agent" @ line 1, column 1.

* chore(docker) add image to build

* feat(docker): Trying to get the branch name as the docker image tag.

* fix(docker): Trying to use a variable for the docker image name as...

Tag must follow the pattern &#039;^:[a-zA-Z0-9_]([a-zA-Z0-9_.-]){0,127}&#039;

* fix(docker): No such property: $DOCKER_IMAGE_NAME for class: groovy.lang.Binding

* fix(docker): No such property: $env for class: groovy.lang.Binding

https://stackoverflow.com/a/59877617/2938320

* fix(docker): ERROR: Bad imageName format: null

* fix(docker): expecting '}', found '' @ line 109, column 1.

* fix(docker): ${env.DOCKER_IMAGE_NAME} cannot be used as a value directly.

Did you mean "${env.DOCKER_IMAGE_NAME}"? (add quotes)

* fix(docker): Unable to contact docker apparently

Remote call on JNLP4-connect connection from 172.18.0.1/172.18.0.1:60178 failed

* fix(docker): There are no nodes with the label ‘linux ubuntu docker

* fix(docker) use a function to get the branch name

* fix(docker) get the right branch name

Is is possible to get the branch name in the on/push/branches?

* fix(docker): $HOME not defined is maybe the root cause of all my problems.

* fix(docker): it looks like the last image is not always pulled

* fix(jenkins): is $HOME finally set?

* fix(jenkins): $HOME is, what else could be the `?` ?

* fix(docker): another try at getting the Jenkins user right.

* chore(android): Updated a few dependencies and removed jcenter.

* fix(docker): another try at getting the Jenkins user right.

* Conditional docker building (#40)

* feat(github): Should only build the docker image if Dockerfile got changed.

* feat(github): Should only build the docker image if Dockerfile got changed.

* feat(github): Should only build the docker image if Dockerfile got changed.

* feat(github): Should only build the docker image if Dockerfile got changed.

* feat(github): Should only build the docker image if Dockerfile got changed.

* feat(android): Added the first static analytics tools

* feat(android): Added the first static analytics tools

* fix(android): Removed temporarily the detekt tool.

Problems to set it up.

* fix(android): detekt wants the `.kt` files to end up with a newline.

* fix(android): detekt wants the `.kt` files to end up with a newline.

* fix(android): detekt generated its own config file.

* chore(android): New patch version

This way, we should see if the application goes up to the Play Store.

* fix(docker) The build has to happen in the main branch.

* Bump com.github.spotbugs from 4.7.1 to 5.0.9 (#54)

Bumps com.github.spotbugs from 4.7.1 to 5.0.9.

---
updated-dependencies:
- dependency-name: com.github.spotbugs
  dependency-type: direct:production
  update-type: version-update:semver-major
...

Signed-off-by: dependabot[bot] <support@github.com>

Signed-off-by: dependabot[bot] <support@github.com>
Co-authored-by: dependabot[bot] <49699333+dependabot[bot]@users.noreply.github.com>

* Add gradle wrapper binary (#57)

* chore(docker): Allow docker to copy everything but...

* feat(docker): Docker should now download the correct version of gradle

* chore(docker): GitHub action has to use the add-gradle-wrapper-binary to build

* fix(jenkins): where does gradlew store the gradle jar?

* fix(jenkins): is there anything in the wrapper dir?

* fix(jenkins): is there anything in the wrapper dir?

* fix(jenkins): nothing in target dir :'(

Would there be anything after the first gradle command in the container using our image?

* fix(jenkins): nothing in target dir :'(

Would there be anything after the first gradle command in the container using our image?

* fix(jenkins): unexpected char: '\' @ line 24, column 67.

* fix(docker): Trying to find the gradle jar

* fix(docker): Trying to find the gradle jar

* fix(docker): Trying to find the gradle jar

* fix(docker): Trying to find the gradle jar

* fix(docker): Trying to find the gradle jar

* fix(docker): Trying to find the gradle jar

* feat(jenkins) Can detekt autocorrect?

* feat(android) First level of tests

* feat(github) Docker image building should now react on...

`.dockerignore` and `gradle/wrapper/gradle-wrapper.properties`.

* fix(github) misprint

The workflow is not valid. .github/workflows/docker-image.yml (Line: 33, Col: 13): Unexpected symbol: 'v'. Located at position 86 within expression: steps.filter.outputs.docker == 'true' || steps.filter.outputs.docker-ignore == 'true'v || steps.filter.outputs.grqdle-zrqpper == 'true'

* chore(docker) Move to JDK17

* feat(android) Added the buildToolsVersion to be used later on to configure the Docker image.

* fix(github) "Dockerfile" as an answer does not seem to work.

Let's try with `true`

* fix(github) The test was not well written

* fix(github) The test was not well written

* fix(github) The workflow is not valid.

.github/workflows/docker-image.yml (Line: 37, Col: 9): Unrecognized named-value: 'paths-filter'. Located at position 1 within expression: paths-filter.changes.outputs.docker == 'true' || paths-filter.changes.outputs.docker-ignore == 'true' || paths-filter.changes.outputs.gradle-wrapper == 'true'

* fix(github) You have an error in your yaml syntax on line 8

`*` is not a valid branch name. `'*'` is.

* fix(github) Changes output set to ["docker","docker-ignore"]

Let's compare with an empty array?

* fix(github) Unexpected symbol: '['. Ugly hack

https://github.com/orgs/community/discussions/27125#discussioncomment-3254717

* fix(github) Too few parameters supplied: '('.

https://github.com/orgs/community/discussions/27125#discussioncomment-3254717

* fix(github) Too few parameters supplied: '('.

https://github.com/orgs/community/discussions/27125#discussioncomment-3254717

* fix(github) Unexpected symbol: '‘'.

https://github.com/orgs/community/discussions/27125#discussioncomment-3254717

* fix(github) Still false...

* feat(docker) Let's see if the gradle dist zip file is there

* feat(docker) Let's see if the gradle dist zip file is there

* feat(docker) Let's see if the gradle dist zip file is there

* feat(docker) Let's see if the gradle dist zip file is there

* feat(docker) Let's see if the gradle dist zip file is there

* fix(jenkins) We don't have any device connected yet

* fix(jenkins) We don't have any device connected yet, do we?

* feat(docker) adb binary is needed to connect

* Docker image tag name (#59)

* fix(docker) invalid tag "***/***:refs/pull/57/merge": invalid reference format

* fix(jenkins) if we change the nomenclature for the dockerfile tag in the GH workflow...

We also have to change it within Jenkins.

Signed-off-by: dependabot[bot] <support@github.com>
Co-authored-by: dependabot[bot] <49699333+dependabot[bot]@users.noreply.github.com>

* fix(jenkins) No need to do static analysis to test qodana

* fix(jenkins) No need to do static analysis to test qodana

* feat(jenkins) one agent per stage now, as we will have to use different images.

* fix(jenkins) No such property: GIT_BRANCH for class: groovy.lang.Binding

* fix(jenkins) pull access denied for jetbrains/qodana-android, repository does not exist

* feat(android) Added qodana configuration file

* fix(android) Violations limit exceeded by 0 errors, 12 warnings.

Let's push to 15.

* fix(jenkins) No need to checkout, right?

* fix(jenkins) No need to checkout, right?

* fix(jenkins) No need to checkout, right?

* fix(jenkins) Avoid the Jenkins agent running in Docker on top of Windows

* feat(docker) Help from Damien to get DinD running in my agents.

* feat(docker) Add a checksum for the maven binary

* feat(docker) Android SDK is back.

* feat(jenkins) Have a distinct name for each stage

* feat(jenkins) First try at Jcasc.

* feat(jenkins) Gitpodization

* fix(docker) Warning: Failed to find package 'ndk;21.4.7075529'

* chore(git) no secrets, sorry.

* fix(jcasc) Agents should have the `docker` and `ubuntu` labels.

* feat(docker) Adding a named data volume and a few ENV variables for secrets.

* feat(docker) Poor man's Jcasc.

Adding First Job as a job that will appear in any new controller instance when using this Dockerfile.

* feat(jcasc) First try at getting the GitHub app credentials.

* feat(jcasc) First try at getting a First Job as part of the initial installation

* feat(jenkins) Added multi branch Android pipeline.

* fix(docker) Expose port 50000

* feat(jenkins) Add a second agent (with GCP) in Jcasc configuration

* fix(jenkins) Added GITHUB_APP_ID instead of clear app id.

* fix(jenkins) 4 seems more reasonable for 8 vCPUs

* fix(docker) We don't need DinD in the image that will be used by the agent.

* fix(docker) Specific image for the agent now

* fix(docker) Specific image for the agent now

Signed-off-by: dependabot[bot] <support@github.com>
Co-authored-by: dependabot[bot] <49699333+dependabot[bot]@users.noreply.github.com>

* fix(docker) YAML indentation

* Damien cleanup (#71)

* feat(ci/cd): Now builds with the static docker agent

Hopefully... Trying to get a docker agent to take the dockerfile, build a docker image, and use it to build the app

BREAKING CHANGE: Have to have a static docker agent able to take the build

* feat(docker): Install docker in the image

Will that be enough to get DinD?

* feat(docker): Start from Debian instead of ssh-agent

Will that be enough to get DinD?

* fix(docker): chown: invalid user: 'jenkins:jenkins'

* fix(docker): developer and not developers

* feat(docker): Install docker for non root user

To run Docker as a non-privileged user, consider setting up the Docker daemon in rootless mode for your user.
Visit https://docs.docker.com/go/rootless/ to learn about rootless mode.

* feat(docker): Do not install docker for non root user

Refusing to install rootless Docker as the root user

* chore(docker): Now using Android SDK Build-Tools 30.0.3

* chore(docker): No need to know the docker version

* chore(docker): No need to install the recommended software

* chore(android): Updated a few dependencies. New patch version.

- androidx.lifecycle:lifecycle-livedata-ktx:2.5.1
- androidx.lifecycle:lifecycle-viewmodel-ktx:2.5.1
- androidx.navigation:navigation-fragment-ktx:2.5.1
- androidx.navigation:navigation-ui-ktx:2.5.1

* fix(jenkins): gradle may need a signin profile even for compiling.

* fix(android): Trying to fix debug.keystore.lock does not exist

Parent directory of /home/jenkins/workspace/Pipeline stored on GitHub repo/?/.gradle/daemon/7.3.3/?/.android/debug.keystore.lock does not exist

* fix(jenkins): is the checkout really necessary?

* fix(jenkins): Expected one of "steps", "stages", or "parallel" for stage "Checkout"

* fix(gradle) android should work now

* fix(docker): No more dockerfile: true because of bugs

* fix(docker): Missing required section "agent" @ line 1, column 1.

* fix(docker): Missing required section "agent" @ line 1, column 1.

* chore(docker) add image to build

* feat(docker): Trying to get the branch name as the docker image tag.

* fix(docker): Trying to use a variable for the docker image name as...

Tag must follow the pattern &#039;^:[a-zA-Z0-9_]([a-zA-Z0-9_.-]){0,127}&#039;

* fix(docker): No such property: $DOCKER_IMAGE_NAME for class: groovy.lang.Binding

* fix(docker): No such property: $env for class: groovy.lang.Binding

https://stackoverflow.com/a/59877617/2938320

* fix(docker): ERROR: Bad imageName format: null

* fix(docker): expecting '}', found '' @ line 109, column 1.

* fix(docker): ${env.DOCKER_IMAGE_NAME} cannot be used as a value directly.

Did you mean "${env.DOCKER_IMAGE_NAME}"? (add quotes)

* fix(docker): Unable to contact docker apparently

Remote call on JNLP4-connect connection from 172.18.0.1/172.18.0.1:60178 failed

* fix(docker): There are no nodes with the label ‘linux ubuntu docker

* fix(docker) use a function to get the branch name

* fix(docker) get the right branch name

Is is possible to get the branch name in the on/push/branches?

* fix(docker): $HOME not defined is maybe the root cause of all my problems.

* fix(docker): it looks like the last image is not always pulled

* fix(jenkins): is $HOME finally set?

* fix(jenkins): $HOME is, what else could be the `?` ?

* fix(docker): another try at getting the Jenkins user right.

* chore(android): Updated a few dependencies and removed jcenter.

* fix(docker): another try at getting the Jenkins user right.

* Conditional docker building (#40)

* feat(github): Should only build the docker image if Dockerfile got changed.

* feat(github): Should only build the docker image if Dockerfile got changed.

* feat(github): Should only build the docker image if Dockerfile got changed.

* feat(github): Should only build the docker image if Dockerfile got changed.

* feat(github): Should only build the docker image if Dockerfile got changed.

* feat(android): Added the first static analytics tools

* feat(android): Added the first static analytics tools

* fix(android): Removed temporarily the detekt tool.

Problems to set it up.

* fix(android): detekt wants the `.kt` files to end up with a newline.

* fix(android): detekt wants the `.kt` files to end up with a newline.

* feat(android) Add a qodana docker stage

* fix(docker) Now builds the docker image for the qodana branch

* feat(action) Try to guess if the image already exists

* Get latest commits merged into qodana branch (#61)

* Create codacy.yml

* Bump gradle from 7.2.1 to 7.2.2 (#36)

Bumps gradle from 7.2.1 to 7.2.2.

---
updated-dependencies:
- dependency-name: com.android.tools.build:gradle
  dependency-type: direct:production
  update-type: version-update:semver-patch
...

Signed-off-by: dependabot[bot] <support@github.com>

Co-authored-by: dependabot[bot] <49699333+dependabot[bot]@users.noreply.github.com>

* Release drafter (#37)

* Syntax is now correct.

* Added the configuration file.

* Only works on the `main` branch.

* chore(android): Upgrade semantic version plugin to 1.2.0

* Closes #34 (#38)

* Syntax is now correct.

* Added the configuration file.

* Only works on the `main` branch.

* chore(android): Upgrade semantic version plugin to 1.2.0

* feat(github): Supposed to resolve #34

* chore(android): Upgrade version to 1.0.17

* Dynamic docker (#50)

* feat(ci/cd): Now builds with the static docker agent

Hopefully... Trying to get a docker agent to take the dockerfile, build a docker image, and use it to build the app

BREAKING CHANGE: Have to have a static docker agent able to take the build

* feat(docker): Install docker in the image

Will that be enough to get DinD?

* feat(docker): Start from Debian instead of ssh-agent

Will that be enough to get DinD?

* fix(docker): chown: invalid user: 'jenkins:jenkins'

* fix(docker): developer and not developers

* feat(docker): Install docker for non root user

To run Docker as a non-privileged user, consider setting up the Docker daemon in rootless mode for your user.
Visit https://docs.docker.com/go/rootless/ to learn about rootless mode.

* feat(docker): Do not install docker for non root user

Refusing to install rootless Docker as the root user

* chore(docker): Now using Android SDK Build-Tools 30.0.3

* chore(docker): No need to know the docker version

* chore(docker): No need to install the recommended software

* chore(android): Updated a few dependencies. New patch version.

- androidx.lifecycle:lifecycle-livedata-ktx:2.5.1
- androidx.lifecycle:lifecycle-viewmodel-ktx:2.5.1
- androidx.navigation:navigation-fragment-ktx:2.5.1
- androidx.navigation:navigation-ui-ktx:2.5.1

* fix(jenkins): gradle may need a signin profile even for compiling.

* fix(android): Trying to fix debug.keystore.lock does not exist

Parent directory of /home/jenkins/workspace/Pipeline stored on GitHub repo/?/.gradle/daemon/7.3.3/?/.android/debug.keystore.lock does not exist

* fix(jenkins): is the checkout really necessary?

* fix(jenkins): Expected one of "steps", "stages", or "parallel" for stage "Checkout"

* fix(gradle) android should work now

* fix(docker): No more dockerfile: true because of bugs

* fix(docker): Missing required section "agent" @ line 1, column 1.

* fix(docker): Missing required section "agent" @ line 1, column 1.

* chore(docker) add image to build

* feat(docker): Trying to get the branch name as the docker image tag.

* fix(docker): Trying to use a variable for the docker image name as...

Tag must follow the pattern &#039;^:[a-zA-Z0-9_]([a-zA-Z0-9_.-]){0,127}&#039;

* fix(docker): No such property: $DOCKER_IMAGE_NAME for class: groovy.lang.Binding

* fix(docker): No such property: $env for class: groovy.lang.Binding

https://stackoverflow.com/a/59877617/2938320

* fix(docker): ERROR: Bad imageName format: null

* fix(docker): expecting '}', found '' @ line 109, column 1.

* fix(docker): ${env.DOCKER_IMAGE_NAME} cannot be used as a value directly.

Did you mean "${env.DOCKER_IMAGE_NAME}"? (add quotes)

* fix(docker): Unable to contact docker apparently

Remote call on JNLP4-connect connection from 172.18.0.1/172.18.0.1:60178 failed

* fix(docker): There are no nodes with the label ‘linux ubuntu docker

* fix(docker) use a function to get the branch name

* fix(docker) get the right branch name

Is is possible to get the branch name in the on/push/branches?

* fix(docker): $HOME not defined is maybe the root cause of all my problems.

* fix(docker): it looks like the last image is not always pulled

* fix(jenkins): is $HOME finally set?

* fix(jenkins): $HOME is, what else could be the `?` ?

* fix(docker): another try at getting the Jenkins user right.

* chore(android): Updated a few dependencies and removed jcenter.

* fix(docker): another try at getting the Jenkins user right.

* Conditional docker building (#40)

* feat(github): Should only build the docker image if Dockerfile got changed.

* feat(github): Should only build the docker image if Dockerfile got changed.

* feat(github): Should only build the docker image if Dockerfile got changed.

* feat(github): Should only build the docker image if Dockerfile got changed.

* feat(github): Should only build the docker image if Dockerfile got changed.

* feat(android): Added the first static analytics tools

* feat(android): Added the first static analytics tools

* fix(android): Removed temporarily the detekt tool.

Problems to set it up.

* fix(android): detekt wants the `.kt` files to end up with a newline.

* fix(android): detekt wants the `.kt` files to end up with a newline.

* fix(android): detekt generated its own config file.

* chore(android): New patch version

This way, we should see if the application goes up to the Play Store.

* fix(docker) The build has to happen in the main branch.

* Bump com.github.spotbugs from 4.7.1 to 5.0.9 (#54)

Bumps com.github.spotbugs from 4.7.1 to 5.0.9.

---
updated-dependencies:
- dependency-name: com.github.spotbugs
  dependency-type: direct:production
  update-type: version-update:semver-major
...

Signed-off-by: dependabot[bot] <support@github.com>

Signed-off-by: dependabot[bot] <support@github.com>
Co-authored-by: dependabot[bot] <49699333+dependabot[bot]@users.noreply.github.com>

* Add gradle wrapper binary (#57)

* chore(docker): Allow docker to copy everything but...

* feat(docker): Docker should now download the correct version of gradle

* chore(docker): GitHub action has to use the add-gradle-wrapper-binary to build

* fix(jenkins): where does gradlew store the gradle jar?

* fix(jenkins): is there anything in the wrapper dir?

* fix(jenkins): is there anything in the wrapper dir?

* fix(jenkins): nothing in target dir :'(

Would there be anything after the first gradle command in the container using our image?

* fix(jenkins): nothing in target dir :'(

Would there be anything after the first gradle command in the container using our image?

* fix(jenkins): unexpected char: '\' @ line 24, column 67.

* fix(docker): Trying to find the gradle jar

* fix(docker): Trying to find the gradle jar

* fix(docker): Trying to find the gradle jar

* fix(docker): Trying to find the gradle jar

* fix(docker): Trying to find the gradle jar

* fix(docker): Trying to find the gradle jar

* feat(jenkins) Can detekt autocorrect?

* feat(android) First level of tests

* feat(github) Docker image building should now react on...

`.dockerignore` and `gradle/wrapper/gradle-wrapper.properties`.

* fix(github) misprint

The workflow is not valid. .github/workflows/docker-image.yml (Line: 33, Col: 13): Unexpected symbol: 'v'. Located at position 86 within expression: steps.filter.outputs.docker == 'true' || steps.filter.outputs.docker-ignore == 'true'v || steps.filter.outputs.grqdle-zrqpper == 'true'

* chore(docker) Move to JDK17

* feat(android) Added the buildToolsVersion to be used later on to configure the Docker image.

* fix(github) "Dockerfile" as an answer does not seem to work.

Let's try with `true`

* fix(github) The test was not well written

* fix(github) The test was not well written

* fix(github) The workflow is not valid.

.github/workflows/docker-image.yml (Line: 37, Col: 9): Unrecognized named-value: 'paths-filter'. Located at position 1 within expression: paths-filter.changes.outputs.docker == 'true' || paths-filter.changes.outputs.docker-ignore == 'true' || paths-filter.changes.outputs.gradle-wrapper == 'true'

* fix(github) You have an error in your yaml syntax on line 8

`*` is not a valid branch name. `'*'` is.

* fix(github) Changes output set to ["docker","docker-ignore"]

Let's compare with an empty array?

* fix(github) Unexpected symbol: '['. Ugly hack

https://github.com/orgs/community/discussions/27125#discussioncomment-3254717

* fix(github) Too few parameters supplied: '('.

https://github.com/orgs/community/discussions/27125#discussioncomment-3254717

* fix(github) Too few parameters supplied: '('.

https://github.com/orgs/community/discussions/27125#discussioncomment-3254717

* fix(github) Unexpected symbol: '‘'.

https://github.com/orgs/community/discussions/27125#discussioncomment-3254717

* fix(github) Still false...

* feat(docker) Let's see if the gradle dist zip file is there

* feat(docker) Let's see if the gradle dist zip file is there

* feat(docker) Let's see if the gradle dist zip file is there

* feat(docker) Let's see if the gradle dist zip file is there

* feat(docker) Let's see if the gradle dist zip file is there

* fix(jenkins) We don't have any device connected yet

* fix(jenkins) We don't have any device connected yet, do we?

* feat(docker) adb binary is needed to connect

* Docker image tag name (#59)

* fix(docker) invalid tag "***/***:refs/pull/57/merge": invalid reference format

* fix(jenkins) if we change the nomenclature for the dockerfile tag in the GH workflow...

We also have to change it within Jenkins.

Signed-off-by: dependabot[bot] <support@github.com>
Co-authored-by: dependabot[bot] <49699333+dependabot[bot]@users.noreply.github.com>

* fix(jenkins) No need to do static analysis to test qodana

* fix(jenkins) No need to do static analysis to test qodana

* feat(jenkins) one agent per stage now, as we will have to use different images.

* fix(jenkins) No such property: GIT_BRANCH for class: groovy.lang.Binding

* fix(jenkins) pull access denied for jetbrains/qodana-android, repository does not exist

* feat(android) Added qodana configuration file

* fix(android) Violations limit exceeded by 0 errors, 12 warnings.

Let's push to 15.

* fix(jenkins) No need to checkout, right?

* fix(jenkins) No need to checkout, right?

* fix(jenkins) No need to checkout, right?

* fix(jenkins) Avoid the Jenkins agent running in Docker on top of Windows

* feat(docker) Help from Damien to get DinD running in my agents.

* feat(docker) Add a checksum for the maven binary

* feat(docker) Android SDK is back.

* feat(jenkins) Have a distinct name for each stage

* feat(jenkins) First try at Jcasc.

* feat(jenkins) Gitpodization

* fix(docker) Warning: Failed to find package 'ndk;21.4.7075529'

* chore(git) no secrets, sorry.

* fix(jcasc) Agents should have the `docker` and `ubuntu` labels.

* feat(docker) Adding a named data volume and a few ENV variables for secrets.

* feat(docker) Poor man's Jcasc.

Adding First Job as a job that will appear in any new controller instance when using this Dockerfile.

* feat(jcasc) First try at getting the GitHub app credentials.

* feat(jcasc) First try at getting a First Job as part of the initial installation

* feat(jenkins) Added multi branch Android pipeline.

* fix(docker) Expose port 50000

* feat(jenkins) Add a second agent (with GCP) in Jcasc configuration

* fix(jenkins) Added GITHUB_APP_ID instead of clear app id.

* fix(jenkins) 4 seems more reasonable for 8 vCPUs

* fix(docker) We don't need DinD in the image that will be used by the agent.

* fix(docker) Specific image for the agent now

* fix(docker) Specific image for the agent now

* fix(docker) Controller had problems connecting to the agent.

* fix(docker) Controller had problems connecting to the agent.

* fix(docker) Added `/var/run/docker.sock` as a new volume.

* fix(docker) No need to add `jenkins` in the `docker` group.

* fix(docker) Bash should be enough for the standard client, no need to use ssh server.

* fix(docker) Switch from DinD to DonD.

* No more dond (#70)

* fix(docker) Adding an `android` agent to avoid DonD.

* fix(docker) Adding an `android` agent to avoid DonD.

* fix(docker) Now using the `ssh-agent` base entrypoint

* fix(docker) `chown` and `chmod` whenever the `docker.sock` belongs to root.

* feat(jenkins) now uses a dedicated `android` agent

Instead of a `DonD` generic one.

* fix(jenkins) Let's use directly the agent with the right docker image

instead of using it through a docker image.

* fix(jenkins) Let's use directly the agent with the right docker image

instead of using it through a docker image.

* fix(jenkins) `gradlew: permission denied

Signed-off-by: dependabot[bot] <support@github.com>
Co-authored-by: dependabot[bot] <49699333+dependabot[bot]@users.noreply.github.com>

* chore(android) Move to version 1.1.3

* fix(gps) ./gradlew: Permission denied

Signed-off-by: dependabot[bot] <support@github.com>
Co-authored-by: dependabot[bot] <49699333+dependabot[bot]@users.noreply.github.com>

* chore(android) Change androidx.appcompat:appcompat dependency to 1.5.0

* fix(gps) /gradlew: No such file or directory

Signed-off-by: dependabot[bot] <support@github.com>
Co-authored-by: dependabot[bot] <49699333+dependabot[bot]@users.noreply.github.com>