### PR TITLE
Stf (#420)

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -29,7 +29,7 @@ updates:
     ignore:
       - dependency-name: "jenkins/jenkins"
   - package-ecosystem: docker
-    directory: "./adb-connector"
+    directory: "./jenkins/adb-connector"
     schedule:
       interval: weekly
     open-pull-requests-limit: 10

--- a/.github/workflows/plugins-update.yml
+++ b/.github/workflows/plugins-update.yml
@@ -1,0 +1,72 @@
+name: Plugins Update file test
+
+on:
+  workflow_dispatch:
+    
+  schedule:
+    - cron: '0 0 * * *' # run daily at midnight
+
+    
+jobs:
+  check-plugins:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v3
+      
+      - name: Configure git & gh
+        run: |
+          
+          echo ${{ secrets.GH_TOKEN }} | gh auth login --with-token
+          gh auth status
+          git config --global user.email "gounthar@gmail.com"
+          git config --global user.name "gounthar"
+
+      - name: Set branch Names and start the containers
+        run: |
+          #  Set the name of the branch to create the pull request from
+          echo "BRANCH_NAME=update-plugins-$(date +'%Y/%m/%d/%H/%M/%S')" >> $GITHUB_ENV
+
+          # Set the name of the branch to create the pull request to
+          echo "BASE_BRANCH=${GITHUB_REF#refs/heads/}" >> $GITHUB_ENV
+
+          # Start the docker containers
+          cd jenkins && docker compose up -d
+
+      - name: print GITHUB_ENV file
+        run: cat $GITHUB_ENV
+        
+      - name: Waiting for service to be ready
+        run: |
+          # Check If Jenkins is running or not
+          # If the message is found, awk exits with a non-zero status (1), and the loop continues.
+          # If the message is not found, the loop exits, and the "Jenkins is running" message is displayed.
+          timeout 60 bash -c 'until curl -s -f http://127.0.0.1:8080/login > /dev/null; do sleep 5; done' && echo "Jenkins is running" || echo "Jenkins is not running" 
+          echo "Jenkins is ready"
+          JENKINS_VERSION=$(curl -s -I -k http://admin:butler@127.0.0.1:8080 | grep -i '^X-Jenkins:' | awk '{print $2}')
+          echo "Jenkins version is: $JENKINS_VERSION"
+
+
+          # Uses jenkins-plugin-cli to update the plugin.txt and update it 
+          docker ps | grep controller | awk '{print $1}' | xargs -I {} docker exec {} jenkins-plugin-cli --plugin-file /usr/share/jenkins/ref/plugins.txt --no-download --available-updates --output txt > controller/plugins.txt
+          # Check if the plugins.txt file has been modified
+          if git diff --quiet -- controller/plugins.txt; then
+              # No changes
+              echo "No plugins need to be updated"
+          else
+              # Changes detected
+              echo "Plugins have been updated, creating a pull request"
+
+              # Create and checkout new branch
+              git checkout -b "$BRANCH_NAME" 
+
+              # Add and commit changes
+              git add controller/plugins.txt
+              git commit -m "chore(jenkins): Update Jenkins plugins"
+
+              # Push changes to GitHub
+              git push -u origin "$BRANCH_NAME"
+
+              # Create pull request using gh command
+              gh pr create --title "chore(jenkins): Updates Jenkins plugins" --body "This pull request updates the Jenkins plugins listed in \`plugins.txt\`." --base "$BASE_BRANCH" --head "$BRANCH_NAME"
+          fi

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM jenkins/ssh-agent:5.10.0-jdk17 as ssh-agent
+FROM jenkins/ssh-agent:5.11.0-jdk17 as ssh-agent
 
 # ca-certificates because curl will need it later on for the Maven installation
 RUN apt-get update && apt-get install -y --no-install-recommends adb build-essential ca-certificates curl file git python3 python3-pip unzip

--- a/jenkins/adb-connector/Dockerfile
+++ b/jenkins/adb-connector/Dockerfile
@@ -1,4 +1,4 @@
-FROM jenkins/ssh-agent:5.10.0-jdk17 as ssh-agent
+FROM jenkins/ssh-agent:5.11.0-jdk17 as ssh-agent
 
 # ca-certificates because curl will need it later on for the Maven installation
 RUN apt-get update && apt-get install -y --no-install-recommends adb build-essential ca-certificates curl file git unzip

--- a/jenkins/agent/Dockerfile
+++ b/jenkins/agent/Dockerfile
@@ -1,4 +1,4 @@
-FROM jenkins/ssh-agent:5.10.0-jdk17 as ssh-agent
+FROM jenkins/ssh-agent:5.11.0-jdk17 as ssh-agent
 
 
 # ca-certificates because curl will need it later on for the Maven installation


### PR DESCRIPTION
* Update plugins.txt for  plugins (#174)



* feat(docker) First version of the STF Farm using the emulator.

* Update plugins.txt for  plugins (#178)



* Update plugins.txt for  plugins (#179)



* feat(docker) Now copying the publishing job as the poor man's jcasc too.

* feat(docker) Now using variables for STF.

* feat(docker) Now adb connects to a real Android device if any connected/configured.

* feat(jenkins) Connecting to STF and not directly to the emulator.

* feat(jenkins) Connecting to STF and not directly to the emulator.

* feat(stf) Not publishing as localhost, but as stf now.

* feat(stf) Using a `PUBLIC_IP`declared variable (in .env).

* feat(docker) Using a `PUBLIC_IP`declared variable (in .env).

* feat(jenkins) Using a `PUBLIC_IP`declared variable (in .env).

* feat(jenkins) Added a `PUBLIC_IP` variable declared (in .env).

* feat(android) Removed tools:targetApi="donut"

Not necessary anymore.

* feat(docker) Added android keys.

* Update plugins.txt for  plugins (#180)



* feat(jenkins) Added a STF API token as credential.

* feat(jenkins) First version of the android stf script.

* feat(jenkins) Installing the STF script and the Android ADB keys.

* feat(jenkins) First try with the STF script.

* feat(jenkins) Adding the STF public IP in JCasc.

* Update plugins.txt for  plugins (#183)



* fix(jenkins) Now uses the right STF token.

* fix(stf) No need to use proxies.

* chore(android) Move to `gradle` plugin 7.3.1.

* feat(jenkins) Doesn't use direct connection to the emulator anymore.

Now uses STF to borrow a device.

* fix(docker) Now gives `STF_HOST_NAME` as an environment variable.

* fix(android) Corrected typo.

* fix(jenkins) Keep using the lock while disconnecting.

* Update plugins.txt for  plugins (#184)



* fix(docker) Changed the health check for the emulator.

From an idea of Damien that I reported there:  https://github.com/google/android-emulator-container-scripts/issues/313#issuecomment-1280780041

* Update plugins.txt for  plugins (#188)



* Update plugins.txt for  plugins (#191)



* Update plugins.txt for  plugins (#194)



* fix(jcasc) Configuration as Code obsolete file format:

'jnlp' is obsolete, please use 'inbound'

* chore(plugons) Update plugins.txt for plugins (#200)



* chore(android) Dependencies update and new version (1.1.11)

com.google.android.material:material:1.6.1=>1.7.0
androidx.navigation:navigation-fragment-ktx:2.5.2=>2.5.3 androidx.navigation:navigation-ui-ktx:2.5.2=>2.5.3 androidx.test.ext:junit:1.1.3=>1.1.4
androidx.test.espresso:espresso-core:3.4.0=>3.5.0

* Update plugins.txt for  plugins (#202)

chore(dependencies) Co-authored-by: 220265 <116569+gounthar@users.noreply.github.com>

* chore(jenkins) Update plugins.txt for  plugins (#204)



* chore(android) Move kotlin-gradle-plugin to 1.7.20

* chore(dependencies) Update plugins.txt for  plugins (#209)



* chore(dependencies) Update plugins.txt for  plugins (#213)



* chore(dependencies) Update plugins.txt for  plugins (#215)



* Update plugins.txt for  plugins (#216)



* chore(plugins) Removes WMI Windows Agents Plugin

* Update plugins.txt for workflow-cps (#222)

checks-api plugins



* feat(jenkins) Now rebuilds regularly

* Update plugins.txt for  plugins (#224)



* Update plugins.txt for  plugins (#227)



* Update plugins.txt for  plugins (#232)



* Update plugins.txt for  plugins (#235)



* Update plugins.txt for jaxb plugins (#245)



* chore(android): Few deps upgrade

* Update plugins.txt for  plugins (#246)



* Update plugins.txt for  plugins (#247)



* feat(documentation): Adds a link and badge for GitHub codespace.

* fix(documentation): Now proposes a new workspace instead of reusing mine.

* fix(documentation): No link in a link.

* Create devcontainer.json

* Update plugins.txt for snakeyaml-api (#248)

email-ext
cloudbees-bitbucket-branch-source
workflow-basic-steps
docker-java-api
workflow-durable-task-step
workflow-multibranch
timestamper
schedule-build
javax-activation-api
workflow-cps
jakarta-mail-api
gradle
jakarta-activation-api
resource-disposer
github
javax-mail-api
lockable-resources
jnr-posix-api
pipeline-build-step
okhttp-api plugins



* Update plugins.txt for snakeyaml-api (#250)

email-ext
cloudbees-bitbucket-branch-source
workflow-basic-steps
docker-java-api
workflow-durable-task-step
workflow-multibranch
timestamper
schedule-build
javax-activation-api
workflow-cps
jakarta-mail-api
gradle
jakarta-activation-api
resource-disposer
github
javax-mail-api
lockable-resources
jnr-posix-api
pipeline-build-step
okhttp-api plugins



* Update plugins.txt for  plugins (#251)



* chore(android): Few deps upgrade

* chore(jenkins): Removed deprecated plugins.

* chore(docker): Moved to qodana-jvm-android:2022.3-eap.

* fix(gradle): Failed to apply plugin 'com.android.internal.version-check'.

Minimum supported Gradle version is 7.5. Current version is 7.4. If using the gradle wrapper, try editing the distributionUrl in /home/jenkins/workspace/06b99dfa0340600130224a0fe2b30f35/gradle/wrapper/gradle-wrapper.properties to gradle-7.5-all.zip

* Update plugins.txt for  plugins (#258)



* Update plugins.txt for  plugins (#264)



* chore(deps): Upgraded androix.lifecycle dependencies.

* chore(deps): Upgraded gradle-plugin dependency.

org.jetbrains.kotlin:kotlin-gradle-plugin:1.8.10 dependency.

* fix(android): A failure occurred while executing CheckDuplicatesRunnable

A failure occurred while executing com.android.build.gradle.internal.tasks.CheckDuplicatesRunnable
11:40:34     > Duplicate class kotlin.collections.jdk8.CollectionsJDK8Kt

* chore(deps): A failure occurred while executing CheckDuplicatesRunnable

Duplicate class kotlin.collections.jdk8.CollectionsJDK8Kt found in modules jetified-kotlin-stdlib-1.8.10 (org.jetbrains.kotlin:kotlin-stdlib:1.8.10) and jetified-kotlin-stdlib-jdk8-1.7.20 (org.jetbrains.kotlin:kotlin-stdlib-jdk8:1.7.20)

* chore(deps): Dependencies update and cache settings.

* fix(gradle): 5 problems were found storing the configuration cache

3 of which seem unique.
             14:42:05  - Task `:app:evaluateViolations` of type `com.gradleup.staticanalysis.EvaluateViolationsTask`: cannot serialize object of type 'org.gradle.api.internal.project.DefaultProject', a subtype of 'org.gradle.api.Project', as these are not supported with the configuration cache.
             14:42:05    See https://docs.gradle.org/7.5/userguide/configuration_cache.html#config_cache:requirements:disallowed_types
             14:42:05  - Task `:app:spotbugsDebug` of type `com.github.spotbugs.snom.SpotBugsTask`: invocation of 'Task.project' at execution time is unsupported.
             14:42:05    See https://docs.gradle.org/7.5/userguide/configuration_cache.html#config_cache:requirements:use_project_during_execution
             14:42:05  - Task `:app:spotbugsRelease` of type `com.github.spotbugs.snom.SpotBugsTask`: invocation of 'Task.project' at execution time is unsupported.
             14:42:05    See https://docs.gradle.org/7.5/userguide/configuration_cache.html#config_cache:requirements:use_project_during_execution

* Update plugins.txt for  plugins (#268)



* chore(deps): Update plugins.txt for configuration-as-code plugins (#272)



* chore(deps): Update plugins.txt for  plugins (#273)



* chore(deps): Update plugins.txt for workflow-cps (#276)

workflow-durable-task-step
workflow-job plugins



* chore(deps): Update plugins.txt for  plugins (#279)



* feat(github): Let's try to build an `aarch64` docker image.

* Update plugins.txt for  plugins (#296)



* Update plugins.txt for  plugins (#310)



* Update plugins.txt for  plugins (#318)



* Update plugins.txt for  plugins (#328)



* Update plugins.txt for  plugins (#329)



* chore(plugins): Removed deprecated plugins

* Update plugins.txt for  plugins (#332)



* chore(plugins): Removed deprecated plugins

* Update plugins.txt (#341)

* Update plugins.txt for  plugins

* Update jenkins/controller/plugins.txt

* Update jenkins/controller/plugins.txt

---------




* Update plugins.txt for  plugins (#346)



* Update plugins.txt for  plugins (#347)



* Update plugins.txt for  plugins (#365)



* Update plugins.txt for  plugins (#369)



* Update plugins.txt for  plugins (#375)



* Update plugins.txt for  plugins (#382)



* chore(docker): Updated qodana base image.

* chore(jenkins): Removed scary plugin :-D

* Update plugins.txt for  plugins (#385)



* Update plugins.txt for  plugins (#387)



* Update plugins.txt for  plugins (#388)



* Update plugins.txt for  plugins (#390)



* chore(jenkins): Added pipeline graph view and removed blue ocean.

* Update plugins.txt for  plugins (#393)



* Update plugins.txt for  plugins (#400)



* Update plugins.txt for  plugins (#408)



* Update plugins.txt for  plugins (#410)



* Stf gradle update (#412)

* Update plugins.txt for  plugins (#407)



* chore(android): Gradle update

* Another try

* chore(android): Gradle update

* Update plugins.txt for  plugins (#411)



* fix(posix): Compliance

POSIX is your friend

---------



* Update dependabot.yml

---------